### PR TITLE
Add authentication and user management API endpoints

### DIFF
--- a/backend/accounts/admin.py
+++ b/backend/accounts/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/backend/accounts/apps.py
+++ b/backend/accounts/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class AccountsConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'accounts'

--- a/backend/accounts/forms.py
+++ b/backend/accounts/forms.py
@@ -1,0 +1,21 @@
+from django.contrib.auth.forms import UserCreationForm, UserChangeForm
+from django.contrib.auth.models import User
+from django import forms
+
+class CustomUserCreationForm(UserCreationForm):
+    email = forms.EmailField(max_length=50)
+    first_name = forms.CharField(max_length=50)
+    last_name = forms.CharField(max_length=50)
+
+    class Meta:
+        model = User
+        fields = [ 'id', 'first_name', 'last_name', 'username', 'email', 'password1', 'password2' ]
+
+class CustomUserChangeForm(UserChangeForm):
+    email = forms.EmailField(max_length=50)
+    first_name = forms.CharField(max_length=50)
+    last_name = forms.CharField(max_length=50)
+
+    class Meta:
+        model = User
+        fields = [ 'id', 'first_name', 'last_name', 'username', 'email', 'date_joined' ]

--- a/backend/accounts/forms.py
+++ b/backend/accounts/forms.py
@@ -18,4 +18,4 @@ class CustomUserChangeForm(UserChangeForm):
 
     class Meta:
         model = User
-        fields = [ 'id', 'first_name', 'last_name', 'username', 'email', 'date_joined' ]
+        fields = [ 'id', 'first_name', 'last_name', 'username', 'email']

--- a/backend/accounts/models.py
+++ b/backend/accounts/models.py
@@ -1,0 +1,3 @@
+from django.db import models
+
+# Create your models here.

--- a/backend/accounts/models.py
+++ b/backend/accounts/models.py
@@ -1,3 +1,3 @@
-from django.db import models
+from django.contrib.auth.models import User
 
-# Create your models here.
+User._meta.get_field('email')._unique = True

--- a/backend/accounts/templates/emails/reset_password.html
+++ b/backend/accounts/templates/emails/reset_password.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Reset password</title>
+</head>
+<body>
+    <h1>Password Reset Request</h1>
+    <p>Hi {{ name }}, Click the link below to reset your password:</p>
+    <a href="{{url}}/{{uid}}/{{token}}">
+        Reset Password
+    </a>
+    <div>
+        <strong>Note: Password reset token will be expire after 5 minutes...</strong>
+        <p>If you didn't request a password reset, you can safely ignore this email.</p>
+    </div>
+</body>
+</html>

--- a/backend/accounts/tests.py
+++ b/backend/accounts/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/backend/accounts/tests.py
+++ b/backend/accounts/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/backend/accounts/tests/test_forms.py
+++ b/backend/accounts/tests/test_forms.py
@@ -20,8 +20,8 @@ class TestCustomUserCreationForm:
         assert User.objects.count() == 0
 
         form = CustomUserCreationForm(form_attributes)
-        
-        assert form.is_valid() == True
+
+        assert form.is_valid()
         form.save()
         assert User.objects.count() == 1
         user = User.objects.last()
@@ -29,11 +29,11 @@ class TestCustomUserCreationForm:
         assert user.email == 'user1@xyz.com'
         assert user.first_name == 'abc'
         assert user.last_name == '123'
-        
+
     def test_user_creation_form_without_attributes(self):
         form = CustomUserCreationForm({})
-        
-        assert form.is_valid() == False
+
+        assert not form.is_valid()
         assert 'This field is required.' in form.errors['username']
         assert 'This field is required.' in form.errors['email']
         assert 'This field is required.' in form.errors['password1']
@@ -45,16 +45,16 @@ class TestCustomUserCreationForm:
         User.objects.create(username= 'user1', email='user2@xyz.com')
 
         form = CustomUserCreationForm(form_attributes)
-        
-        assert form.is_valid() == False
+
+        assert not form.is_valid()
         assert 'A user with that username already exists.' in form.errors['username']
 
     def test_user_creation_form_with_email_already_exists(self, form_attributes):
         User.objects.create(username= 'user2', email='user1@xyz.com')
 
         form = CustomUserCreationForm(form_attributes)
-        
-        assert form.is_valid() == False
+
+        assert not form.is_valid()
         assert 'User with this Email address already exists.' in form.errors['email']
 
     def test_user_creation_form_with_username_having_invalid_character(self, form_attributes):
@@ -62,45 +62,45 @@ class TestCustomUserCreationForm:
 
         form = CustomUserCreationForm(form_attributes)
 
-        assert form.is_valid() == False
+        assert not form.is_valid()
         assert 'Enter a valid username. This value may contain only letters, numbers, and @/./+/-/_ characters.' in form.errors['username']
 
     def test_user_creation_form_with_shorter_password(self, form_attributes):
         form_attributes['password1'] = "123"
         form_attributes['password2'] = "123"
-        
+
         form = CustomUserCreationForm(form_attributes)
-        
-        assert form.is_valid() == False
+
+        assert not form.is_valid()
         assert 'This password is too short. It must contain at least 8 characters.' in form.errors['password2']
-    
+
     def test_user_creation_form_with_common_password(self, form_attributes):
         form_attributes['password1'] = "password123"
         form_attributes['password2'] = "password123"
-        
+
         form = CustomUserCreationForm(form_attributes)
-        
-        assert form.is_valid() == False
+
+        assert not form.is_valid()
         assert 'This password is too common.' in form.errors['password2']
-    
+
     def test_user_creation_form_with_only_numeric_password(self, form_attributes):
         form_attributes['password1'] = "12345678"
         form_attributes['password2'] = "12345678"
-        
+
         form = CustomUserCreationForm(form_attributes)
-        
-        assert form.is_valid() == False
+
+        assert not form.is_valid()
         assert 'This password is entirely numeric.' in form.errors['password2']
-    
+
     def test_user_creation_form_with_different_passwords(self, form_attributes):
         form_attributes['password1'] = "password123"
         form_attributes['password2'] = "password456"
-        
+
         form = CustomUserCreationForm(form_attributes)
-        
-        assert form.is_valid() == False
+
+        assert not form.is_valid()
         assert 'The two password fields didn’t match.' in form.errors['password2']
-    
+
 @pytest.mark.django_db
 class TestCustomUserChangeForm:
 
@@ -128,9 +128,9 @@ class TestCustomUserChangeForm:
         assert user.email == 'user1@xyz.com'
         assert user.first_name == 'abc'
         assert user.last_name == '123'
-        
+
         form = CustomUserChangeForm(instance=user, data=form_attributes)
-        assert form.is_valid() == True
+        assert form.is_valid()
         form.save()
         assert user.username == 'user2'
         assert user.email == 'user2@xyz.com'
@@ -139,8 +139,8 @@ class TestCustomUserChangeForm:
 
     def test_user_change_form_without_attributes(self):
         form = CustomUserChangeForm({})
-        
-        assert form.is_valid() == False
+
+        assert not form.is_valid()
         assert 'This field is required.' in form.errors['username']
         assert 'This field is required.' in form.errors['email']
         assert 'This field is required.' in form.errors['first_name']
@@ -149,15 +149,15 @@ class TestCustomUserChangeForm:
     def test_user_change_form_with_username_already_exists(self, form_attributes):
         form_attributes['username'] = 'user1'
         form = CustomUserChangeForm(form_attributes)
-        
-        assert form.is_valid() == False
+
+        assert not form.is_valid()
         assert 'A user with that username already exists.' in form.errors['username']
 
     def test_user_change_form_with_email_already_exists(self, form_attributes):
         form_attributes['email'] = 'user1@xyz.com'
         form = CustomUserChangeForm(form_attributes)
-        
-        assert form.is_valid() == False
+
+        assert not form.is_valid()
         assert 'User with this Email address already exists.' in form.errors['email']
 
     def test_user_change_username_having_invalid_character(self, form_attributes):
@@ -165,5 +165,5 @@ class TestCustomUserChangeForm:
 
         form = CustomUserChangeForm(form_attributes)
 
-        assert form.is_valid() == False
+        assert not form.is_valid()
         assert 'Enter a valid username. This value may contain only letters, numbers, and @/./+/-/_ characters.' in form.errors['username']

--- a/backend/accounts/tests/test_forms.py
+++ b/backend/accounts/tests/test_forms.py
@@ -1,0 +1,169 @@
+import pytest
+from django.contrib.auth.models import User
+from accounts.forms import CustomUserCreationForm, CustomUserChangeForm
+
+@pytest.mark.django_db
+class TestCustomUserCreationForm:
+
+    @pytest.fixture
+    def form_attributes(self):
+        return {
+            'username': 'user1',
+            'email': 'user1@xyz.com',
+            'password1': 'Password#123',
+            'password2': 'Password#123',
+            'first_name': 'abc',
+            'last_name': '123'
+        }
+
+    def test_user_creation_form(self, form_attributes):
+        assert User.objects.count() == 0
+
+        form = CustomUserCreationForm(form_attributes)
+        
+        assert form.is_valid() == True
+        form.save()
+        assert User.objects.count() == 1
+        user = User.objects.last()
+        assert user.username == 'user1'
+        assert user.email == 'user1@xyz.com'
+        assert user.first_name == 'abc'
+        assert user.last_name == '123'
+        
+    def test_user_creation_form_without_attributes(self):
+        form = CustomUserCreationForm({})
+        
+        assert form.is_valid() == False
+        assert 'This field is required.' in form.errors['username']
+        assert 'This field is required.' in form.errors['email']
+        assert 'This field is required.' in form.errors['password1']
+        assert 'This field is required.' in form.errors['password2']
+        assert 'This field is required.' in form.errors['first_name']
+        assert 'This field is required.' in form.errors['last_name']
+
+    def test_user_creation_form_with_username_already_exists(self, form_attributes):
+        User.objects.create(username= 'user1', email='user2@xyz.com')
+
+        form = CustomUserCreationForm(form_attributes)
+        
+        assert form.is_valid() == False
+        assert 'A user with that username already exists.' in form.errors['username']
+
+    def test_user_creation_form_with_email_already_exists(self, form_attributes):
+        User.objects.create(username= 'user2', email='user1@xyz.com')
+
+        form = CustomUserCreationForm(form_attributes)
+        
+        assert form.is_valid() == False
+        assert 'User with this Email address already exists.' in form.errors['email']
+
+    def test_user_creation_form_with_username_having_invalid_character(self, form_attributes):
+        form_attributes['username'] = 'User 1'
+
+        form = CustomUserCreationForm(form_attributes)
+
+        assert form.is_valid() == False
+        assert 'Enter a valid username. This value may contain only letters, numbers, and @/./+/-/_ characters.' in form.errors['username']
+
+    def test_user_creation_form_with_shorter_password(self, form_attributes):
+        form_attributes['password1'] = "123"
+        form_attributes['password2'] = "123"
+        
+        form = CustomUserCreationForm(form_attributes)
+        
+        assert form.is_valid() == False
+        assert 'This password is too short. It must contain at least 8 characters.' in form.errors['password2']
+    
+    def test_user_creation_form_with_common_password(self, form_attributes):
+        form_attributes['password1'] = "password123"
+        form_attributes['password2'] = "password123"
+        
+        form = CustomUserCreationForm(form_attributes)
+        
+        assert form.is_valid() == False
+        assert 'This password is too common.' in form.errors['password2']
+    
+    def test_user_creation_form_with_only_numeric_password(self, form_attributes):
+        form_attributes['password1'] = "12345678"
+        form_attributes['password2'] = "12345678"
+        
+        form = CustomUserCreationForm(form_attributes)
+        
+        assert form.is_valid() == False
+        assert 'This password is entirely numeric.' in form.errors['password2']
+    
+    def test_user_creation_form_with_different_passwords(self, form_attributes):
+        form_attributes['password1'] = "password123"
+        form_attributes['password2'] = "password456"
+        
+        form = CustomUserCreationForm(form_attributes)
+        
+        assert form.is_valid() == False
+        assert 'The two password fields didn’t match.' in form.errors['password2']
+    
+@pytest.mark.django_db
+class TestCustomUserChangeForm:
+
+    @pytest.fixture
+    def user(self):
+        return User.objects.create(
+            username= 'user1',
+            email= 'user1@xyz.com',
+            first_name= 'abc',
+            last_name= '123'
+        )
+
+    @pytest.fixture
+    def form_attributes(self, user):
+        return {
+            'id': user.id,
+            'username': 'user2',
+            'email': 'user2@xyz.com',
+            'first_name': 'xyz',
+            'last_name': '456'
+        }
+
+    def test_user_change_form(self, user, form_attributes):
+        assert user.username == 'user1'
+        assert user.email == 'user1@xyz.com'
+        assert user.first_name == 'abc'
+        assert user.last_name == '123'
+        
+        form = CustomUserChangeForm(instance=user, data=form_attributes)
+        assert form.is_valid() == True
+        form.save()
+        assert user.username == 'user2'
+        assert user.email == 'user2@xyz.com'
+        assert user.first_name == 'xyz'
+        assert user.last_name == '456'
+
+    def test_user_change_form_without_attributes(self):
+        form = CustomUserChangeForm({})
+        
+        assert form.is_valid() == False
+        assert 'This field is required.' in form.errors['username']
+        assert 'This field is required.' in form.errors['email']
+        assert 'This field is required.' in form.errors['first_name']
+        assert 'This field is required.' in form.errors['last_name']
+
+    def test_user_change_form_with_username_already_exists(self, form_attributes):
+        form_attributes['username'] = 'user1'
+        form = CustomUserChangeForm(form_attributes)
+        
+        assert form.is_valid() == False
+        assert 'A user with that username already exists.' in form.errors['username']
+
+    def test_user_change_form_with_email_already_exists(self, form_attributes):
+        form_attributes['email'] = 'user1@xyz.com'
+        form = CustomUserChangeForm(form_attributes)
+        
+        assert form.is_valid() == False
+        assert 'User with this Email address already exists.' in form.errors['email']
+
+    def test_user_change_username_having_invalid_character(self, form_attributes):
+        form_attributes['username'] = 'User 1'
+
+        form = CustomUserChangeForm(form_attributes)
+
+        assert form.is_valid() == False
+        assert 'Enter a valid username. This value may contain only letters, numbers, and @/./+/-/_ characters.' in form.errors['username']

--- a/backend/accounts/tests/test_models.py
+++ b/backend/accounts/tests/test_models.py
@@ -1,0 +1,60 @@
+import pytest
+from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
+from django.db.utils import IntegrityError
+
+@pytest.mark.django_db
+class TestUser:
+
+    @pytest.fixture
+    def user(self):
+        return User.objects.create(
+            username='User1',
+            email='user1@xyz.com',
+            password='password123',
+            first_name='abc',
+            last_name='123'
+        )
+
+    def test_user_creation(self, user):
+        user.full_clean()
+        assert user.username == 'User1'
+    
+    def test_user_creation_duplicate_username(self, user):
+        with pytest.raises(IntegrityError) as exception_info:
+            User.objects.create(
+                username='User1',
+                email='user2@xyz.com',
+                password='password123',
+            )
+        
+        assert str(exception_info.value) == 'UNIQUE constraint failed: auth_user.username'
+
+    def test_user_creation_duplicate_email(self, user):
+        with pytest.raises(IntegrityError) as exception_info:
+            User.objects.create(
+                username='User2',
+                email='user1@xyz.com',
+                password='password123',
+            )
+        
+        assert str(exception_info.value) == 'UNIQUE constraint failed: auth_user.email'
+
+    def test_user_creation_username_having_invalid_character(self, user):
+        with pytest.raises(ValidationError) as exception_info:
+            user2 = User.objects.create(
+                username='User 1',
+                email='user2@xyz.com',
+                password='password123',
+            )
+            user2.full_clean()
+        
+        assert 'Enter a valid username. This value may contain only letters, numbers, and @/./+/-/_ characters.' in exception_info.value.message_dict['username']
+
+    def test_user_creation_without_attributes(self):
+        with pytest.raises(ValidationError) as exception_info:
+            user2 = User.objects.create()
+            user2.full_clean()
+
+        assert 'This field cannot be blank.' in exception_info.value.message_dict['username']
+        assert 'This field cannot be blank.' in exception_info.value.message_dict['password']

--- a/backend/accounts/tests/test_models.py
+++ b/backend/accounts/tests/test_models.py
@@ -19,7 +19,7 @@ class TestUser:
     def test_user_creation(self, user):
         user.full_clean()
         assert user.username == 'User1'
-    
+
     def test_user_creation_duplicate_username(self, user):
         with pytest.raises(IntegrityError) as exception_info:
             User.objects.create(
@@ -27,7 +27,7 @@ class TestUser:
                 email='user2@xyz.com',
                 password='password123',
             )
-        
+
         assert str(exception_info.value) == 'UNIQUE constraint failed: auth_user.username'
 
     def test_user_creation_duplicate_email(self, user):
@@ -37,7 +37,7 @@ class TestUser:
                 email='user1@xyz.com',
                 password='password123',
             )
-        
+
         assert str(exception_info.value) == 'UNIQUE constraint failed: auth_user.email'
 
     def test_user_creation_username_having_invalid_character(self, user):
@@ -48,7 +48,7 @@ class TestUser:
                 password='password123',
             )
             user2.full_clean()
-        
+
         assert 'Enter a valid username. This value may contain only letters, numbers, and @/./+/-/_ characters.' in exception_info.value.message_dict['username']
 
     def test_user_creation_without_attributes(self):

--- a/backend/accounts/tests/test_views.py
+++ b/backend/accounts/tests/test_views.py
@@ -1,0 +1,477 @@
+import pytest
+from django.test import Client
+from django.contrib.auth.models import User
+from django.core import mail
+from django.utils.http import urlsafe_base64_encode
+from django.utils.encoding import force_bytes
+from django.contrib.auth.tokens import default_token_generator
+import json
+
+@pytest.fixture
+def user():
+    return User.objects.create_user(
+        username='user1',
+        email='user1@xyz.com',
+        password='Password#123',
+        first_name='abc',
+        last_name='123'
+    )
+
+@pytest.fixture
+def client():
+    return Client()
+
+@pytest.fixture
+def logged_in_client(user):
+    client = Client()
+    client.login(username='user1', password='Password#123')
+    return client
+
+def test_csrf_view(client):
+    response = client.get('/auth/csrf')
+
+    assert response.status_code == 200
+    assert 'csrftoken' in response.cookies, 'CSRF Token is missing in response'
+    assert json.loads(response.content)['message'] == 'CSRF token set successfully.'
+
+@pytest.mark.django_db
+class TestWhoAmIView:
+    def test_whoami_view_with_user_logged_in(self, logged_in_client, user):
+        response = logged_in_client.get('/auth/whoami')
+
+        assert response.status_code == 200
+        assert json.loads(response.content)['user']['id'] == user.id
+        assert json.loads(response.content)['user']['username'] == 'user1'
+
+    def test_whoami_view_with_user_logged_in(self, client):
+        response = client.get('/auth/whoami')
+
+        assert response.status_code == 401
+        assert json.loads(response.content)['error'] == 'User not authenticated.'
+
+@pytest.mark.django_db
+class TestRegisterView:
+    
+    @pytest.fixture
+    def form_attributes(self):
+        return {
+            'username': 'user1',
+            'email': 'user2@xyz.com',
+            'password1': 'Password#123',
+            'password2': 'Password#123',
+            'first_name': 'abc',
+            'last_name': '123'
+        }
+    
+    def test_register_view(self, client, form_attributes):
+        response = client.post('/auth/register',
+            data=json.dumps(form_attributes),
+            content_type='application/json'
+        )
+
+        assert response.status_code == 201
+        assert json.loads(response.content)['message'] == 'User registered successfully.'
+    
+    def test_register_view_with_get_request(self, client, form_attributes):
+        response = client.get('/auth/register')
+
+        assert response.status_code == 405
+    
+    def test_register_view_with_username_already_exists(self, client, user, form_attributes):
+        response = client.post('/auth/register',
+            data=json.dumps(form_attributes),
+            content_type='application/json'
+        )
+
+        assert response.status_code == 400
+        assert 'A user with that username already exists.' in json.loads(response.content)['errors']['username']
+    
+    def test_register_view_with_email_already_exists(self, client, user, form_attributes):
+        form_attributes['username'] = 'user2'
+        form_attributes['email'] = 'user1@xyz.com'
+
+        response = client.post('/auth/register',
+            data=json.dumps(form_attributes),
+            content_type='application/json'
+        )
+
+        assert response.status_code == 400
+        assert 'User with this Email address already exists.' in json.loads(response.content)['errors']['email']
+    
+    def test_register_view_without_attributes(self, client):
+        response = client.post('/auth/register',
+            data=json.dumps({}),
+            content_type='application/json'
+        )
+
+        assert response.status_code == 400
+        errors = json.loads(response.content)['errors']
+        assert 'This field is required.' in errors['username']
+        assert 'This field is required.' in errors['email']
+        assert 'This field is required.' in errors['password1']
+        assert 'This field is required.' in errors['password2']
+        assert 'This field is required.' in errors['first_name']
+        assert 'This field is required.' in errors['last_name']
+    
+    def test_register_view_with_username_having_invalid_character(self, client, form_attributes):
+        form_attributes['username'] = 'User 1'
+
+        response = client.post('/auth/register',
+            data=json.dumps(form_attributes),
+            content_type='application/json'
+        )
+
+        assert response.status_code == 400
+        assert 'Enter a valid username. This value may contain only letters, numbers, and @/./+/-/_ characters.' in json.loads(response.content)['errors']['username']
+
+    def test_register_view_with_shorter_password(self, client, form_attributes):
+        form_attributes['password1'] = "123"
+        form_attributes['password2'] = "123"
+        
+        response = client.post('/auth/register',
+            data=json.dumps(form_attributes),
+            content_type='application/json'
+        )
+
+        assert response.status_code == 400
+        assert 'This password is too short. It must contain at least 8 characters.' in json.loads(response.content)['errors']['password2']
+    
+    def test_register_view_with_common_password(self, client, form_attributes):
+        form_attributes['password1'] = "password123"
+        form_attributes['password2'] = "password123"
+        
+        response = client.post('/auth/register',
+            data=json.dumps(form_attributes),
+            content_type='application/json'
+        )
+
+        assert response.status_code == 400
+        assert 'This password is too common.' in json.loads(response.content)['errors']['password2']
+    
+    def test_register_view_with_only_numeric_password(self, client, form_attributes):
+        form_attributes['password1'] = "12345678"
+        form_attributes['password2'] = "12345678"
+        
+        response = client.post('/auth/register',
+            data=json.dumps(form_attributes),
+            content_type='application/json'
+        )
+
+        assert response.status_code == 400
+        assert 'This password is entirely numeric.' in json.loads(response.content)['errors']['password2']
+    
+    def test_register_view_with_different_passwords(self, client, form_attributes):
+        form_attributes['password1'] = "password123"
+        form_attributes['password2'] = "password456"
+        
+        response = client.post('/auth/register',
+            data=json.dumps(form_attributes),
+            content_type='application/json'
+        )
+
+        assert response.status_code == 400
+        assert 'The two password fields didn’t match.' in json.loads(response.content)['errors']['password2']
+
+@pytest.mark.django_db
+class TestLoginView:
+    
+    @pytest.fixture
+    def form_attributes(self):
+        return {
+            'username': 'user1',
+            'password': 'Password#123',
+        }
+    
+    def test_login_view_with_valid_credentials(self, client, user, form_attributes):
+        response = client.post('/auth/login',
+            data=json.dumps(form_attributes),
+            content_type='application/json'
+        )
+
+        assert response.status_code == 200
+        assert json.loads(response.content)['message'] == 'User logged in successfully.'
+
+    def test_login_view_with_valid_credentials(self, client, user, form_attributes):
+        form_attributes['password'] = 'password123'
+        response = client.post('/auth/login',
+            data=json.dumps(form_attributes),
+            content_type='application/json'
+        )
+
+        assert response.status_code == 401
+        assert json.loads(response.content)['message'] == 'Invalid credential: Either User name or password is incorrect.'
+    
+    def test_login_view_with_get_request(self, client, form_attributes):
+        response = client.get('/auth/login')
+
+        assert response.status_code == 405
+
+@pytest.mark.django_db
+class TestLogoutView:
+    
+    def test_logout_view_without_user_logged_in(self, client):
+        response = client.post('/auth/logout')
+
+        assert response.status_code == 200
+        assert json.loads(response.content)['message'] == 'User logged out successfully.'
+
+    def test_logout_view_with_user_logged_in(self, logged_in_client, user):
+        response = logged_in_client.post('/auth/logout')
+
+        assert response.status_code == 200
+        assert json.loads(response.content)['message'] == 'User logged out successfully.'
+
+    def test_logout_view_with_get_request(self, client):
+        response = client.get('/auth/logout')
+
+        assert response.status_code == 405
+
+@pytest.mark.django_db
+class TestUpdateUserView:
+
+    @pytest.fixture
+    def form_attributes(self, user):
+        return {
+            'id': user.id,
+            'username': 'user2',
+            'email': 'user2@xyz.com',
+            'first_name': 'xyz',
+            'last_name': '456'
+        }
+
+    def test_update_user_view(self, logged_in_client, user, form_attributes):
+        assert user.username == 'user1'
+        assert user.email == 'user1@xyz.com'
+        assert user.first_name == 'abc'
+        assert user.last_name == '123'
+
+        response = logged_in_client.post('/auth/update',
+            data=json.dumps(form_attributes),
+            content_type='application/json'
+        )
+
+        assert response.status_code == 200
+        assert json.loads(response.content)['message'] == 'User updated successfully.'
+        user.refresh_from_db()
+        assert user.username == 'user2'
+        assert user.email == 'user2@xyz.com'
+        assert user.first_name == 'xyz'
+        assert user.last_name == '456'
+    
+    def test_update_user_view_with_get_request(self, logged_in_client):
+        response = logged_in_client.get('/auth/update')
+
+        assert response.status_code == 405
+    
+    def test_update_user_view_without_logged_in_user(self, client, form_attributes):
+        response = client.post('/auth/update',
+            data=json.dumps(form_attributes),
+            content_type='application/json'
+        )
+
+        assert response.status_code == 401
+        assert json.loads(response.content)['error'] == 'User not authenticated.'
+
+    def test_update_user_view_with_username_already_exists(self, logged_in_client, form_attributes):
+        user1 = User.objects.create_user(username='user2')
+
+        response = logged_in_client.post('/auth/update',
+            data=json.dumps(form_attributes),
+            content_type='application/json'
+        )
+
+        assert response.status_code == 400
+        assert 'A user with that username already exists.' in json.loads(response.content)['errors']['username']
+    
+    def test_update_user_view_with_email_already_exists(self, logged_in_client, form_attributes):
+        user1 = User.objects.create_user(username='user3', email='user2@xyz.com')
+
+        response = logged_in_client.post('/auth/update',
+            data=json.dumps(form_attributes),
+            content_type='application/json'
+        )
+
+        assert response.status_code == 400
+        assert 'User with this Email address already exists.' in json.loads(response.content)['errors']['email']
+    
+    def test_update_user_view_without_attributes(self, logged_in_client):
+        response = logged_in_client.post('/auth/update',
+            data=json.dumps({}),
+            content_type='application/json'
+        )
+
+        assert response.status_code == 400
+        errors = json.loads(response.content)['errors']
+        assert 'This field is required.' in errors['username']
+        assert 'This field is required.' in errors['email']
+        assert 'This field is required.' in errors['first_name']
+        assert 'This field is required.' in errors['last_name']
+    
+    def test_update_user_view_with_username_having_invalid_character(self, logged_in_client, form_attributes):
+        form_attributes['username'] = 'User 1'
+
+        response = logged_in_client.post('/auth/update',
+            data=json.dumps(form_attributes),
+            content_type='application/json'
+        )
+
+        assert response.status_code == 400
+        assert 'Enter a valid username. This value may contain only letters, numbers, and @/./+/-/_ characters.' in json.loads(response.content)['errors']['username']
+
+@pytest.mark.django_db
+class TestUpdatePasswordView:
+
+    @pytest.fixture
+    def form_attributes(self, user):
+        return {
+            'old_password': 'Password#123',
+            'new_password1': 'new_password123',
+            'new_password2': 'new_password123'
+        }
+
+    def test_update_password_view(self, logged_in_client, user, form_attributes):
+        old_password_hash = user.password
+        response = logged_in_client.post('/auth/update-password',
+            data=json.dumps(form_attributes),
+            content_type='application/json'
+        )
+
+        assert response.status_code == 200
+        assert json.loads(response.content)['message'] == 'Password changed successfully.'
+        user.refresh_from_db()
+        new_password_hash = user.password
+        assert new_password_hash != old_password_hash
+        assert 'sessionid' in response.cookies, 'Session id missing in response'
+
+    def test_update_password_view_with_get_request(self, logged_in_client):
+        response = logged_in_client.get('/auth/update-password')
+
+        assert response.status_code == 405
+    
+    def test_update_password_view_without_attrbites(self, logged_in_client):
+        response = logged_in_client.post('/auth/update-password',
+            data=json.dumps({}),
+            content_type='application/json'
+        )
+
+        assert response.status_code == 400
+        errors = json.loads(response.content)['errors']
+        assert 'This field is required.' in errors['old_password']
+        assert 'This field is required.' in errors['new_password1']
+        assert 'This field is required.' in errors['new_password2']
+    
+    def test_update_password_view_without_logged_in_user(self, client, form_attributes):
+        response = client.post('/auth/update-password',
+            data=json.dumps(form_attributes),
+            content_type='application/json'
+        )
+
+        assert response.status_code == 401
+        assert json.loads(response.content)['error'] == 'User not authenticated.'
+
+    def test_update_password_view_with_invalid_old_password(self, logged_in_client, form_attributes):
+        form_attributes['old_password'] = 'Invalid'
+
+        response = logged_in_client.post('/auth/update-password',
+            data=json.dumps(form_attributes),
+            content_type='application/json'
+        )
+
+        assert response.status_code == 400
+        assert 'Your old password was entered incorrectly. Please enter it again.' in json.loads(response.content)['errors']['old_password']
+
+    def test_update_password_view_with_different_new_passwords(self, logged_in_client, form_attributes):
+        form_attributes['new_password1'] = 'Notsame'
+
+        response = logged_in_client.post('/auth/update-password',
+            data=json.dumps(form_attributes),
+            content_type='application/json'
+        )
+
+        assert response.status_code == 400
+        assert 'The two password fields didn’t match.' in json.loads(response.content)['errors']['new_password2']
+
+@pytest.mark.django_db
+class TestSendResetPasswordEmailView:
+
+    @pytest.fixture
+    def form_attributes(self, user):
+        return {
+            'username': user.username,
+            'redirect': '/reset-password'
+        }
+
+    def test_send_reset_password_email_view(self, client, user, form_attributes):
+        assert len(mail.outbox) == 0
+
+        response = client.post('/auth/send-password-reset-email',
+            data=json.dumps(form_attributes),
+            content_type='application/json',
+            headers={
+                'Origin':'example.com'
+            }
+        )
+
+        assert response.status_code == 200
+        assert json.loads(response.content)['message'] == 'Password reset mail send successfully.'
+        assert len(mail.outbox) == 1
+        assert mail.outbox[0].subject == 'Reset password'
+        assert mail.outbox[0].body == ''
+        assert user.email in mail.outbox[0].to
+
+    def test_send_reset_password_email_view_with_get_request(self, client):
+        assert len(mail.outbox) == 0
+
+        response = client.get('/auth/send-password-reset-email')
+
+        assert response.status_code == 405
+        assert len(mail.outbox) == 0
+    
+    def test_send_reset_password_email_view_without_username(self, client, form_attributes):
+        del form_attributes['username']
+
+        assert len(mail.outbox) == 0
+
+        response = client.post('/auth/send-password-reset-email',
+            data=json.dumps(form_attributes),
+            content_type='application/json',
+            headers={
+                'Origin':'example.com'
+            }
+        )
+        assert response.status_code == 400
+        assert json.loads(response.content)['error'] == repr('username')
+        assert len(mail.outbox) == 0
+
+    def test_send_reset_password_email_view_without_redirect(self, client, form_attributes):
+        del form_attributes['redirect']
+        assert len(mail.outbox) == 0
+ 
+        response = client.post('/auth/send-password-reset-email',
+            data=json.dumps(form_attributes),
+            content_type='application/json',
+            headers={
+                'Origin':'example.com'
+            }
+        )
+
+        assert response.status_code == 400
+        assert json.loads(response.content)['error'] == repr('redirect')
+        assert len(mail.outbox) == 0
+
+    def test_send_reset_password_email_view_with_nonexisting_username(self, client, form_attributes):
+        form_attributes['username'] = 'non_existing_username'
+
+        assert len(mail.outbox) == 0
+
+        response = client.post('/auth/send-password-reset-email',
+            data=json.dumps(form_attributes),
+            content_type='application/json',
+            headers={
+                'Origin':'example.com'
+            }
+        )
+
+        assert response.status_code == 400
+        assert json.loads(response.content)['error'] == 'User matching query does not exist.'
+        assert len(mail.outbox) == 0

--- a/backend/accounts/tests/test_views.py
+++ b/backend/accounts/tests/test_views.py
@@ -202,7 +202,7 @@ class TestLoginView:
         )
 
         assert response.status_code == 401
-        assert json.loads(response.content)['message'] == 'Invalid credential: Either User name or password is incorrect.'
+        assert json.loads(response.content)['error'] == 'Invalid credential: Either User name or password is incorrect.'
         assert 'sessionid' not in response.cookies, 'Session id present in response.'
 
     def test_login_view_with_get_request(self, client):

--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -2,13 +2,13 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path('csrf', views.csrf_view),
-    path('whoami', views.whoami_view),
-    path('register', views.register_view),
-    path('login', views.login_view),
-    path('logout', views.logout_view),
-    path('update', views.update_user_view),
-    path('update-password', views.update_password_view),
-    path('send-password-reset-email', views.send_reset_password_email),
-    path('reset-password', views.reset_password),
+    path('csrf', views.csrf_view, name='csrf'),
+    path('whoami', views.whoami_view, name='whoami'),
+    path('register', views.register_view, name='register'),
+    path('login', views.login_view, name='login'),
+    path('logout', views.logout_view, name='logout'),
+    path('update', views.update_user_view, name='update'),
+    path('update-password', views.update_password_view, name='update-password'),
+    path('send-password-reset-email', views.send_reset_password_email, name='send-password-reset-email'),
+    path('reset-password', views.reset_password, name='reset-password'),
 ]

--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -8,5 +8,7 @@ urlpatterns = [
     path('login', views.login_view),
     path('logout', views.logout_view),
     path('update', views.update_user_view),
-    path('update-password', views.update_password_view)
+    path('update-password', views.update_password_view),
+    path('send-password-reset-email', views.send_reset_password_email),
+    path('reset-password', views.reset_password),
 ]

--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -1,0 +1,12 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('csrf', views.csrf_view),
+    path('whoami', views.whoami_view),
+    path('register', views.register_view),
+    path('login', views.login_view),
+    path('logout', views.logout_view),
+    path('update', views.update_user_view),
+    path('update-password', views.update_password_view)
+]

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -1,9 +1,15 @@
 from django.http import JsonResponse
+from django.template.loader import render_to_string
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_http_methods
-from django.contrib.auth.forms import PasswordChangeForm
+from django.contrib.auth.forms import PasswordChangeForm, SetPasswordForm
 from django.contrib.auth import login, logout, authenticate, update_session_auth_hash
 from django.contrib.auth.models import User
+from django.core.mail import EmailMultiAlternatives
+from django.contrib.auth.tokens import default_token_generator
+from django.conf import settings
+from django.utils.encoding import force_bytes
+from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
 import json
 from .forms import CustomUserCreationForm, CustomUserChangeForm
 
@@ -67,6 +73,7 @@ def update_user_view(request):
     else:
         return JsonResponse({'errors': form.errors}, status=400)
 
+require_http_methods(['POST'])
 def update_password_view(request):
     if not request.user.is_authenticated:
         return JsonResponse({'error': 'User not authenticated'}, status=401)
@@ -80,3 +87,53 @@ def update_password_view(request):
         return JsonResponse({ 'message': 'Password changed successfully' }, status=200)
     else:
         return JsonResponse({'errors': form.errors}, status=400)
+
+require_http_methods(['POST'])
+def send_reset_password_email(request):
+    try:
+        data = json.loads(request.body)
+        user = User.objects.get(username=data['username'])
+
+        origin = request.headers['Origin']
+        url = f"{origin}{data['redirect']}"
+
+        html = render_to_string('emails/reset_password.html', {
+            'name': user.username,
+            'url': url,
+            'uid': urlsafe_base64_encode(force_bytes(user.id)),
+            'token': default_token_generator.make_token(user)
+        })
+
+        msg = EmailMultiAlternatives(
+            'Reset password',
+            '',
+            settings.EMAIL_HOST_USER,
+            [user.email]
+        )
+
+        msg.attach_alternative(html, "text/html")
+        msg.send()
+
+        return JsonResponse({ 'message': 'Mail send successfully successfully' }, status=200)
+    except Exception as e:
+        return JsonResponse({ 'error': str(e) }, status=401)
+
+require_http_methods(['POST'])
+def reset_password(request):
+    try:
+        data = json.loads(request.body)
+        id = urlsafe_base64_decode(data['uid']).decode()
+        user = User.objects.get(pk=id)
+
+        if default_token_generator.check_token(user, data['token']):
+            form = SetPasswordForm(user=user,data={ 'new_password1': data['new_password1'], 'new_password2': data['new_password2'] })
+
+            if form.is_valid():
+                form.save()
+                return JsonResponse({'message': 'Password reset successfully'}, status=200)
+            else:
+                return JsonResponse({'error': form.errors}, status=400)
+        else:
+            return JsonResponse({'error': 'Invalid or expired token'}, status=400)
+    except Exception as e:
+        return JsonResponse({ 'error': str(e) }, status=401)

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -47,7 +47,7 @@ def register_view(request):
 def login_view(request):
     data = json.loads(request.body)
     user = authenticate(request, username=data['username'], password=data['password'])
-    
+
     if user:
         login(request, user)
         return JsonResponse({ 'message': 'User logged in successfully.' }, status=200)
@@ -63,7 +63,7 @@ def logout_view(request):
 def update_user_view(request):
     if not request.user.is_authenticated:
         return JsonResponse({'error': 'User not authenticated.'}, status=401)
-    
+
     data = json.loads(request.body)
     form = CustomUserChangeForm(data, instance=request.user)
 
@@ -77,7 +77,7 @@ def update_user_view(request):
 def update_password_view(request):
     if not request.user.is_authenticated:
         return JsonResponse({'error': 'User not authenticated.'}, status=401)
-    
+
     data=json.loads(request.body)
     form = PasswordChangeForm(user=request.user, data=data)
 

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -26,8 +26,7 @@ def whoami_view(request):
             'username': user.username,
             'email': user.email,
             'first_name': user.first_name,
-            'last_name': user.last_name,
-            'date_joined': user.date_joined
+            'last_name': user.last_name
         }}, status=200)
     return JsonResponse({'message': 'User is not authenticated.'}, status=401)
 

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -52,7 +52,7 @@ def login_view(request):
         login(request, user)
         return JsonResponse({ 'message': 'User logged in successfully.' }, status=200)
     else:
-        return JsonResponse({ 'message': 'Invalid credential: Either User name or password is incorrect.' }, status=401)
+        return JsonResponse({ 'error': 'Invalid credential: Either User name or password is incorrect.' }, status=401)
 
 @require_POST
 def logout_view(request):

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -1,0 +1,82 @@
+from django.http import JsonResponse
+from django.views.decorators.csrf import ensure_csrf_cookie
+from django.views.decorators.http import require_http_methods
+from django.contrib.auth.forms import PasswordChangeForm
+from django.contrib.auth import login, logout, authenticate, update_session_auth_hash
+from django.contrib.auth.models import User
+import json
+from .forms import CustomUserCreationForm, CustomUserChangeForm
+
+@ensure_csrf_cookie
+def csrf_view(request):
+    return JsonResponse({'message': 'CSRF token set successfully'}, status=200)
+
+def whoami_view(request):
+    if request.user.is_authenticated:
+        user = User.objects.get(pk=request.user.id)
+
+        return JsonResponse({ 'user': {
+            'id': user.id,
+            'username': user.username,
+            'email': user.email,
+            'first_name': user.first_name,
+            'last_name': user.last_name,
+            'date_joined': user.date_joined
+        }}, status=200)
+    return JsonResponse({'message': 'User is not authenticated.'}, status=401)
+
+require_http_methods(['POST'])
+def register_view(request):
+    data = json.loads(request.body)
+
+    form = CustomUserCreationForm(data)
+
+    if form.is_valid():
+        form.save()
+        return JsonResponse({'message': 'User registered successfully'}, status=201)
+    else:
+        return JsonResponse({'errors': form.errors}, status=400)
+
+require_http_methods(['POST'])
+def login_view(request):
+    data = json.loads(request.body)
+    user = authenticate(request, username=data['username'], password=data['password'])
+    
+    if user:
+        login(request, user)
+        return JsonResponse({ 'message': 'User logged in successfully' }, status=200)
+    else:
+        return JsonResponse({ 'message': 'Invalid credential: Either User name or password is incorrect' }, status=401)
+
+require_http_methods(['POST'])
+def logout_view(request):
+    logout(request)
+    return JsonResponse({ 'message': 'Logged out successfully' }, status=200)
+
+require_http_methods(['POST'])
+def update_user_view(request):
+    if not request.user.is_authenticated:
+        return JsonResponse({'error': 'User not authenticated'}, status=401)
+    
+    data = json.loads(request.body)
+    form = CustomUserChangeForm(data, instance=request.user)
+
+    if form.is_valid():
+        form.save()
+        return JsonResponse({ 'message': 'User updated successfully' }, status=200)
+    else:
+        return JsonResponse({'errors': form.errors}, status=400)
+
+def update_password_view(request):
+    if not request.user.is_authenticated:
+        return JsonResponse({'error': 'User not authenticated'}, status=401)
+    
+    data=json.loads(request.body)
+    form = PasswordChangeForm(user=request.user, data=data)
+
+    if form.is_valid():
+        form.save()
+        update_session_auth_hash(request, form.user)
+        return JsonResponse({ 'message': 'Password changed successfully' }, status=200)
+    else:
+        return JsonResponse({'errors': form.errors}, status=400)

--- a/backend/project/settings.py
+++ b/backend/project/settings.py
@@ -11,6 +11,10 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
 from pathlib import Path
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -138,3 +142,13 @@ CORS_ALLOWED_ORIGINS = [
 ]
 
 CORS_ALLOW_CREDENTIALS = True
+
+EMAIL_BACKEND = os.environ.get('EMAIL_BACKEND', 'django.core.mail.backends.smtp.EmailBackend')
+EMAIL_HOST = os.environ.get('EMAIL_HOST', 'smtp.gmail.com')
+EMAIL_PORT = int(os.environ.get('EMAIL_PORT', 587))
+EMAIL_USE_TLS = os.environ.get('EMAIL_USE_TLS', 'True') == 'True'
+EMAIL_HOST_USER = os.environ.get('EMAIL_HOST_USER')
+EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD')
+DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL', EMAIL_HOST_USER)
+
+PASSWORD_RESET_TIMEOUT = 300

--- a/backend/project/settings.py
+++ b/backend/project/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'corsheaders',
+    'accounts'
 ]
 
 MIDDLEWARE = [
@@ -123,8 +124,17 @@ STATIC_URL = 'static/'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
+CSRF_TRUSTED_ORIGINS = [
+    'http://localhost:5173',
+    'http://localhost:5174',
+]
+
+CSRF_COOKIE_HTTPONLY = not DEBUG
+CSRF_COOKIE_SECURE = not DEBUG
+
 CORS_ALLOWED_ORIGINS = [
     'http://localhost:5173',
+    'http://localhost:5174',
 ]
 
 CORS_ALLOW_CREDENTIALS = True

--- a/backend/project/urls.py
+++ b/backend/project/urls.py
@@ -15,10 +15,11 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 from .views import health
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('auth/', include('accounts.urls')),
     path('health', health)
 ]

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = project.settings
+python_files = tests.py test_*.py *_tests.py

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
 asgiref==3.8.1
 Django==5.2.1
 django-cors-headers==4.7.0
+python-dotenv==1.1.0
 sqlparse==0.5.3

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,10 @@
 asgiref==3.8.1
 Django==5.2.1
 django-cors-headers==4.7.0
+iniconfig==2.1.0
+packaging==25.0
+pluggy==1.6.0
+pytest==8.3.5
+pytest-django==4.11.1
 python-dotenv==1.1.0
 sqlparse==0.5.3

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import SignUp from './components/SignUp'
 import EditProfile from './components/EditProfile'
 import View from './components/View'
 import ChangePassword from './components/ChangePassword'
+import ProtectedRoute from './components/ProtectedRoute'
 
 function App() {
 
@@ -14,11 +15,14 @@ function App() {
     <Routes>
       <Route path='/' element={<Main />} />
       <Route path='/login' element={<Login />} />
-      <Route path='/logout' element={<Logout />} />
       <Route path='/signup' element={<SignUp />} />
-      <Route path='/view' element={<View />} />
-      <Route path='/edit-profile' element={<EditProfile />} />
-      <Route path='/change-password' element={<ChangePassword />} />
+
+      <Route element={<ProtectedRoute />}>
+        <Route path='/logout' element={<Logout />} />
+        <Route path='/view' element={<View />} />
+        <Route path='/edit-profile' element={<EditProfile />} />
+        <Route path='/change-password' element={<ChangePassword />} />
+      </Route>
     </Routes>
   )
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,8 @@ import EditProfile from './components/EditProfile'
 import View from './components/View'
 import ChangePassword from './components/ChangePassword'
 import ProtectedRoute from './components/ProtectedRoute'
+import ForgetPassword from './components/ForgetPassword'
+import ResetPassword from './components/ResetPassword'
 
 function App() {
 
@@ -16,6 +18,8 @@ function App() {
       <Route path='/' element={<Main />} />
       <Route path='/login' element={<Login />} />
       <Route path='/signup' element={<SignUp />} />
+      <Route path='/forget-password' element={<ForgetPassword />} />
+      <Route path='/reset-password/:uid/:token' element={<ResetPassword />} />
 
       <Route element={<ProtectedRoute />}>
         <Route path='/logout' element={<Logout />} />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,16 +10,20 @@ import ChangePassword from './components/ChangePassword'
 import ProtectedRoute from './components/ProtectedRoute'
 import ForgetPassword from './components/ForgetPassword'
 import ResetPassword from './components/ResetPassword'
+import NonProtectedRoute from './components/NonProtectedRoute'
+import NotFound from './components/NotFound'
 
 function App() {
 
   return (
     <Routes>
-      <Route path='/' element={<Main />} />
-      <Route path='/login' element={<Login />} />
-      <Route path='/signup' element={<SignUp />} />
-      <Route path='/forget-password' element={<ForgetPassword />} />
-      <Route path='/reset-password/:uid/:token' element={<ResetPassword />} />
+      <Route element={<NonProtectedRoute />} >
+        <Route path='/' element={<Main />} />
+        <Route path='/login' element={<Login />} />
+        <Route path='/signup' element={<SignUp />} />
+        <Route path='/forget-password' element={<ForgetPassword />} />
+        <Route path='/reset-password/:uid/:token' element={<ResetPassword />} />
+      </Route>
 
       <Route element={<ProtectedRoute />}>
         <Route path='/logout' element={<Logout />} />
@@ -27,6 +31,8 @@ function App() {
         <Route path='/edit-profile' element={<EditProfile />} />
         <Route path='/change-password' element={<ChangePassword />} />
       </Route>
+
+      <Route path="*" element={<NotFound />} />
     </Routes>
   )
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,30 +1,25 @@
-import { useEffect, useState } from 'react'
 import './App.css'
+import { Routes, Route } from 'react-router-dom'
+import Login from './components/Login'
+import Logout from './components/Logout'
+import Main from './components/Main'
+import SignUp from './components/SignUp'
+import EditProfile from './components/EditProfile'
+import View from './components/View'
+import ChangePassword from './components/ChangePassword'
 
 function App() {
-  const [message, setMessage] = useState('Connecting to database...!')
-
-  useEffect(()=>{
-    const connect = async () => {
-      try {
-        const response = await fetch('http://127.0.0.1:8000/health', {
-          method: 'GET'
-        })
-
-        if (response.status === 200) {
-          setTimeout(()=> setMessage('Backend connected successfully...!'), 300)
-        }
-      }
-      catch {
-        setTimeout(()=> setMessage('Error connecting backend...!'), 300)
-      }
-    }
-
-    connect()
-  },[])
 
   return (
-    <div>{message}</div>
+    <Routes>
+      <Route path='/' element={<Main />} />
+      <Route path='/login' element={<Login />} />
+      <Route path='/logout' element={<Logout />} />
+      <Route path='/signup' element={<SignUp />} />
+      <Route path='/view' element={<View />} />
+      <Route path='/edit-profile' element={<EditProfile />} />
+      <Route path='/change-password' element={<ChangePassword />} />
+    </Routes>
   )
 }
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -6,5 +6,7 @@ export const API = {
     login: 'http://localhost:8000/auth/login',
     logout: 'http://localhost:8000/auth/logout',
     update: 'http://localhost:8000/auth/update',
-    update_password: 'http://localhost:8000/auth/update-password'
+    update_password: 'http://localhost:8000/auth/update-password',
+    send_password_reset_email: 'http://localhost:8000/auth/send-password-reset-email',
+    reset_password: 'http://localhost:8000/auth/reset-password'
 }

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,10 @@
+export const API = {
+    health: 'http://localhost:8000/health',
+    csrf: 'http://localhost:8000/auth/csrf',
+    whoami: 'http://localhost:8000/auth/whoami',
+    register: 'http://localhost:8000/auth/register',
+    login: 'http://localhost:8000/auth/login',
+    logout: 'http://localhost:8000/auth/logout',
+    update: 'http://localhost:8000/auth/update',
+    update_password: 'http://localhost:8000/auth/update-password'
+}

--- a/frontend/src/components/ChangePassword.jsx
+++ b/frontend/src/components/ChangePassword.jsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { API } from '../api'
 import { getCookie } from '../helper'
 import { useAuth } from '../contexts/AuthContext'
@@ -33,7 +33,7 @@ const ChangePassword = () => {
 
 		if (response.status === 200) {
 			setLoading(true)
-      navigate('/view')
+			navigate('/view')
 		} else {
 			const data = await response.json()
 

--- a/frontend/src/components/ChangePassword.jsx
+++ b/frontend/src/components/ChangePassword.jsx
@@ -89,7 +89,7 @@ const ChangePassword = () => {
 					</div>
 					<div className='error'>{formErrors.new_password2}</div>
 				</div>
-				<div className='form-item'>
+				<div className='form-submit'>
 					<button type='submit'>Update</button>
 				</div>
 			</form>

--- a/frontend/src/components/ChangePassword.jsx
+++ b/frontend/src/components/ChangePassword.jsx
@@ -1,0 +1,100 @@
+import { useEffect, useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { API } from '../api'
+import { getCookie } from '../helper'
+import { useAuth } from '../contexts/AuthContext'
+
+const initialState = {
+	old_password: '',
+	new_password1: '',
+	new_password2: '',
+}
+
+const ChangePassword = () => {
+	const [formData, setFormData] = useState(initialState)
+	const [formErrors, setFormErrors] = useState(initialState)
+	const { setLoading } = useAuth()
+	const navigate = useNavigate()
+
+	const updatePassword = async (e) => {
+		e.preventDefault();
+
+		setFormErrors(initialState)
+
+		const response = await fetch(API.update_password, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'X-CSRFToken': getCookie('csrftoken'),
+			},
+			body: JSON.stringify(formData),
+			credentials: 'include'
+		})
+
+		if (response.status === 200) {
+			setLoading(true)
+      navigate('/view')
+		} else {
+			const data = await response.json()
+
+			Object.entries(data.errors).forEach(([key, errors]) => {
+				setFormErrors(prevErrors => ({
+					...prevErrors,
+					[key]: errors.join(', ')
+				}));
+			});
+		}
+	}
+
+	return (
+		<div>
+			<hr />
+			<button onClick={() => navigate(-1)}>Go to back</button>
+			<hr />
+			<h1>Change password</h1>
+			<form onSubmit={updatePassword} className='form'>
+				<div>
+					<div className='form-item'>
+						<label htmlFor='old_password'>Old password</label>
+						<input
+							name='old_password'
+							type='password'
+							value={formData.old_password}
+							onChange={(e) => setFormData({ ...formData, old_password: e.target.value })}
+							placeholder='Enter old password' />
+					</div>
+					<div className='error'>{formErrors.old_password}</div>
+				</div>
+				<div>
+					<div className='form-item'>
+						<label htmlFor='new_password1'>New Password</label>
+						<input
+							name='new_password1'
+							type='password'
+							value={formData.new_password1}
+							onChange={(e) => setFormData({ ...formData, new_password1: e.target.value })}
+							placeholder='Enter new password' />
+					</div>
+					<div className='error'>{formErrors.new_password1}</div>
+				</div>
+				<div>
+					<div className='form-item'>
+						<label htmlFor='new_password2'>Confirm password</label>
+						<input
+							name='new_password2'
+							type='password'
+							value={formData.new_password2}
+							onChange={(e) => setFormData({ ...formData, new_password2: e.target.value })}
+							placeholder='Enter confrim password' />
+					</div>
+					<div className='error'>{formErrors.new_password2}</div>
+				</div>
+				<div className='form-item'>
+					<button type='submit'>Update</button>
+				</div>
+			</form>
+		</div>
+	)
+}
+
+export default ChangePassword

--- a/frontend/src/components/EditProfile.jsx
+++ b/frontend/src/components/EditProfile.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import { API } from '../api'
 import { getCookie } from '../helper'
 import { useAuth } from '../contexts/AuthContext'
@@ -58,14 +58,14 @@ const EditProfile = () => {
   return (
     <div>
       <hr />
-      <button onClick={()=> navigate(-1)}>Go to back</button>
+      <button onClick={() => navigate(-1)}>Go to back</button>
       <hr />
       <h1>Edit profile</h1>
       <form onSubmit={update} className='form'>
         <input
           name='first_name'
           type='hidden'
-          value={formData.date_joined}/>
+          value={formData.date_joined} />
         <div>
           <div className='form-item'>
             <label htmlFor='first_name'>First name</label>

--- a/frontend/src/components/EditProfile.jsx
+++ b/frontend/src/components/EditProfile.jsx
@@ -10,7 +10,6 @@ const initialState = {
   last_name: '',
   username: '',
   email: '',
-  date_joined: ''
 }
 
 const EditProfile = () => {
@@ -62,10 +61,6 @@ const EditProfile = () => {
       <hr />
       <h1>Edit profile</h1>
       <form onSubmit={update} className='form'>
-        <input
-          name='first_name'
-          type='hidden'
-          value={formData.date_joined} />
         <div>
           <div className='form-item'>
             <label htmlFor='first_name'>First name</label>

--- a/frontend/src/components/EditProfile.jsx
+++ b/frontend/src/components/EditProfile.jsx
@@ -1,0 +1,123 @@
+import { useEffect, useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { API } from '../api'
+import { getCookie } from '../helper'
+import { useAuth } from '../contexts/AuthContext'
+
+const initialState = {
+  id: '',
+  first_name: '',
+  last_name: '',
+  username: '',
+  email: '',
+  date_joined: ''
+}
+
+const EditProfile = () => {
+  const [formData, setFormData] = useState(initialState)
+  const [formErrors, setFormErrors] = useState(initialState)
+  const { user, setLoading } = useAuth()
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    setFormData({
+      ...user
+    })
+  }, [user])
+
+  const update = async (e) => {
+    e.preventDefault();
+
+    setFormErrors(initialState)
+
+    const response = await fetch(API.update, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRFToken': getCookie('csrftoken'),
+      },
+      body: JSON.stringify(formData),
+      credentials: 'include'
+    })
+
+    if (response.status === 200) {
+      setLoading(true)
+      navigate('/view')
+    } else {
+      const data = await response.json()
+
+      Object.entries(data.errors).forEach(([key, errors]) => {
+        setFormErrors(prevErrors => ({
+          ...prevErrors,
+          [key]: errors.join(', ')
+        }));
+      });
+    }
+  }
+
+  return (
+    <div>
+      <hr />
+      <button onClick={()=> navigate(-1)}>Go to back</button>
+      <hr />
+      <h1>Edit profile</h1>
+      <form onSubmit={update} className='form'>
+        <input
+          name='first_name'
+          type='hidden'
+          value={formData.date_joined}/>
+        <div>
+          <div className='form-item'>
+            <label htmlFor='first_name'>First name</label>
+            <input
+              name='first_name'
+              value={formData.first_name}
+              onChange={(e) => setFormData({ ...formData, first_name: e.target.value })}
+              placeholder='Enter first name' />
+          </div>
+          <div className='error'>{formErrors.first_name}</div>
+        </div>
+        <div>
+          <div className='form-item'>
+            <label htmlFor='last_name'>Last name</label>
+            <input
+              name='last_name'
+              value={formData.last_name}
+              onChange={(e) => setFormData({ ...formData, last_name: e.target.value })}
+              placeholder='Enter last name' />
+          </div>
+          <div className='error'>{formErrors.last_name}</div>
+        </div>
+        <div>
+          <div className='form-item'>
+            <label htmlFor='username'>User name</label>
+            <input
+              name='username'
+              value={formData.username}
+              onChange={(e) => setFormData({ ...formData, username: e.target.value })}
+              placeholder='Enter username' />
+            <span>This name will be used for login</span>
+          </div>
+          <div className='error'>{formErrors.username}</div>
+        </div>
+        <div>
+          <div className='form-item'>
+            <label htmlFor='email'>Email</label>
+            <input
+              name='email'
+              type='email'
+              value={formData.email}
+              onChange={(e) => setFormData({ ...formData, email: e.target.value })}
+              placeholder='Enter email address' />
+          </div>
+          <div className='error'>{formErrors.email}</div>
+        </div>
+        <div className='form-item'>
+          <button type='submit'>Update</button>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+export default EditProfile

--- a/frontend/src/components/EditProfile.jsx
+++ b/frontend/src/components/EditProfile.jsx
@@ -112,7 +112,7 @@ const EditProfile = () => {
           </div>
           <div className='error'>{formErrors.email}</div>
         </div>
-        <div className='form-item'>
+        <div className='form-submit'>
           <button type='submit'>Update</button>
         </div>
       </form>

--- a/frontend/src/components/ForgetPassword.jsx
+++ b/frontend/src/components/ForgetPassword.jsx
@@ -54,7 +54,7 @@ const ForgetPassword = () => {
 							placeholder='Enter username ...' />
 					</div>
 				</div>
-				<div className='form-item'>
+				<div className='form-submit'>
 					<button type='submit'>Send mail</button>
 				</div>
 			</form>

--- a/frontend/src/components/ForgetPassword.jsx
+++ b/frontend/src/components/ForgetPassword.jsx
@@ -1,0 +1,66 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { API } from '../api'
+import { getCookie } from '../helper'
+
+const ForgetPassword = () => {
+	const [username, setUsername] = useState('')
+	const [error, setError] = useState('')
+	const [success, setSuccess] = useState(false)
+	const navigate = useNavigate()
+
+	const sendResetPasswordMail = async (e) => {
+		e.preventDefault();
+
+		setError('')
+		setSuccess(false)
+
+		const response = await fetch(API.send_password_reset_email, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'X-CSRFToken': getCookie('csrftoken'),
+			},
+			body: JSON.stringify({
+				'username': username,
+				'redirect': '/reset-password'
+			}),
+			credentials: 'include'
+		})
+
+		if (response.status === 200) {
+			setSuccess(true)
+		} else {
+			const data = await response.json()
+			setError(data.message)
+		}
+	}
+
+	return (
+		<div>
+			<hr />
+			<button onClick={() => navigate(-1)}>Go to back</button>
+			<hr />
+			<h1>Forget password</h1>
+			<form onSubmit={sendResetPasswordMail} className='form'>
+				<div className='error'>{error}</div>
+				<div>
+					<div className='form-item'>
+						<label htmlFor='username'>Username</label>
+						<input
+							name='username'
+							value={username}
+							onChange={(e) => setUsername(e.target.value)}
+							placeholder='Enter username ...' />
+					</div>
+				</div>
+				<div className='form-item'>
+					<button type='submit'>Send mail</button>
+				</div>
+			</form>
+			{success && <div>The password reset email send to you mail. You can reset your password now.</div>}
+		</div>
+	)
+}
+
+export default ForgetPassword

--- a/frontend/src/components/ForgetPassword.jsx
+++ b/frontend/src/components/ForgetPassword.jsx
@@ -27,12 +27,11 @@ const ForgetPassword = () => {
 			}),
 			credentials: 'include'
 		})
-
 		if (response.status === 200) {
 			setSuccess(true)
 		} else {
 			const data = await response.json()
-			setError(data.message)
+			setError(data.error)
 		}
 	}
 

--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -71,6 +71,7 @@ const Login = () => {
           <button type='submit'>Login</button>
         </div>
       </form>
+      <div><Link to='/forget-password' >Forget password?</Link></div>
       <div>
         Don't have account? <Link to='/signup'>Sign Up</Link>
       </div>

--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react'
+import { Link, Navigate, useNavigate } from 'react-router-dom'
+import { API } from '../api'
+import { getCookie } from '../helper'
+import { useAuth } from '../contexts/AuthContext'
+
+const Login = () => {
+  const [formData, setFormData] = useState({
+    username: '',
+    password: '',
+  })
+  const [error, setError] = useState('')
+  const navigate = useNavigate()
+  const { user, loading, setLoading } = useAuth()
+
+  const login = async (e) => {
+    e.preventDefault();
+
+    setError('')
+
+    const response = await fetch(API.login, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRFToken': getCookie('csrftoken'),
+      },
+      body: JSON.stringify(formData),
+      credentials: 'include'
+    })
+
+    if (response.status === 200) {
+      setLoading(true)
+      navigate('/view')
+    }
+    else {
+      const data = await response.json()
+      setError(data.message)
+    }
+  }
+
+  if (loading) { return <div>Loading...!</div> }
+  if (user){ return <Navigate to='/view' /> }
+
+  return (
+    <div>
+      <h1>Login your account</h1>
+      <form onSubmit={login} className='form'>
+        <div className='error'>{error}</div>
+        <div>
+          <div className='form-item'>
+            <label htmlFor='username'>User name</label>
+            <input
+              name='username'
+              value={formData.username}
+              onChange={(e) => setFormData({ ...formData, username: e.target.value })}
+              placeholder='Enter username' />
+          </div>
+        </div>
+        <div>
+          <div className='form-item'>
+            <label htmlFor='password'>Password</label>
+            <input
+              name='password'
+              type='password'
+              value={formData.password}
+              onChange={(e) => setFormData({ ...formData, password: e.target.value })}
+              placeholder='Enter password' />
+          </div>
+        </div>
+        <div className='form-item'>
+          <button type='submit'>Login</button>
+        </div>
+      </form>
+      <div>
+        Don't have account? <Link to='/signup'>Sign Up</Link>
+      </div>
+    </div>
+  )
+}
+
+export default Login

--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { Link, Navigate, useNavigate } from 'react-router-dom'
 import { API } from '../api'
 import { getCookie } from '../helper'
@@ -39,7 +39,7 @@ const Login = () => {
   }
 
   if (loading) { return <div>Loading...!</div> }
-  if (user){ return <Navigate to='/view' /> }
+  if (user) { return <Navigate to='/view' /> }
 
   return (
     <div>

--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -64,7 +64,7 @@ const Login = () => {
               placeholder='Enter password' />
           </div>
         </div>
-        <div className='form-item'>
+        <div className='form-submit'>
           <button type='submit'>Login</button>
         </div>
       </form>

--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Link, Navigate, useNavigate } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { API } from '../api'
 import { getCookie } from '../helper'
 import { useAuth } from '../contexts/AuthContext'
@@ -11,7 +11,7 @@ const Login = () => {
   })
   const [error, setError] = useState('')
   const navigate = useNavigate()
-  const { user, loading, setLoading } = useAuth()
+  const { setLoading } = useAuth()
 
   const login = async (e) => {
     e.preventDefault();
@@ -37,9 +37,6 @@ const Login = () => {
       setError(data.message)
     }
   }
-
-  if (loading) { return <div>Loading...!</div> }
-  if (user) { return <Navigate to='/view' /> }
 
   return (
     <div>

--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -34,7 +34,7 @@ const Login = () => {
     }
     else {
       const data = await response.json()
-      setError(data.message)
+      setError(data.error)
     }
   }
 

--- a/frontend/src/components/Logout.jsx
+++ b/frontend/src/components/Logout.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import { API } from '../api'
 import { getCookie } from '../helper'
 import { useAuth } from '../contexts/AuthContext'
@@ -40,9 +40,9 @@ const Logout = () => {
             <div className='error'>{error}</div>
             <h2>Hi {user.username} - Are you sure you want to logout?</h2>
             <button onClick={logout}>Logout</button>
-            <button onClick={()=> navigate(-1)}>Go to back</button>
+            <button onClick={() => navigate(-1)}>Go to back</button>
           </>
-        ): (
+        ) : (
           <div>Loading....</div>
         )
       }

--- a/frontend/src/components/Logout.jsx
+++ b/frontend/src/components/Logout.jsx
@@ -1,0 +1,53 @@
+import { useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { API } from '../api'
+import { getCookie } from '../helper'
+import { useAuth } from '../contexts/AuthContext'
+
+const Logout = () => {
+  const [error, setError] = useState('')
+  const navigate = useNavigate()
+  const { user, setUser, setLoading } = useAuth()
+
+  const logout = async (e) => {
+    setError('')
+
+    const response = await fetch(API.logout, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRFToken': getCookie('csrftoken'),
+      },
+      credentials: 'include'
+    })
+
+    if (response.status === 200) {
+      setLoading(true)
+      setUser(null)
+      navigate('/login')
+    }
+    else {
+      const data = await response.json()
+      setError(data.message)
+    }
+  }
+
+  return (
+    <div>
+      {
+        user ? (
+          <>
+            <div className='error'>{error}</div>
+            <h2>Hi {user.username} - Are you sure you want to logout?</h2>
+            <button onClick={logout}>Logout</button>
+            <button onClick={()=> navigate(-1)}>Go to back</button>
+          </>
+        ): (
+          <div>Loading....</div>
+        )
+      }
+    </div>
+  )
+}
+
+export default Logout

--- a/frontend/src/components/Logout.jsx
+++ b/frontend/src/components/Logout.jsx
@@ -27,8 +27,7 @@ const Logout = () => {
       navigate('/login')
     }
     else {
-      const data = await response.json()
-      setError(data.message)
+      setError('Something went wrong while logging out...!')
     }
   }
 

--- a/frontend/src/components/Main.jsx
+++ b/frontend/src/components/Main.jsx
@@ -10,17 +10,17 @@ const Main = () => {
 		fetch(API.health, {
 			method: 'GET'
 		})
-		.then(response => {
-			if (response.status === 200) {
-				setTimeout(() => {
-					setMessage('Backend connected successfully...!')
-					navigate('/login')
-				}, 300)
-			}
-		})
-		.catch(() => {
-			setMessage('Error connecting backend...!')
-		})
+			.then(response => {
+				if (response.status === 200) {
+					setTimeout(() => {
+						setMessage('Backend connected successfully...!')
+						navigate('/login')
+					}, 300)
+				}
+			})
+			.catch(() => {
+				setMessage('Error connecting backend...!')
+			})
 	}, [])
 
 	return (

--- a/frontend/src/components/Main.jsx
+++ b/frontend/src/components/Main.jsx
@@ -14,7 +14,7 @@ const Main = () => {
 				})
 
 				if (response.status === 200) {
-					setTimeout(() => { 
+					setTimeout(() => {
 						setMessage('Backend connected successfully...!')
 						navigate('/signup')
 					}, 300)

--- a/frontend/src/components/Main.jsx
+++ b/frontend/src/components/Main.jsx
@@ -14,7 +14,7 @@ const Main = () => {
 			if (response.status === 200) {
 				setTimeout(() => {
 					setMessage('Backend connected successfully...!')
-					navigate('/signup')
+					navigate('/login')
 				}, 300)
 			}
 		})

--- a/frontend/src/components/Main.jsx
+++ b/frontend/src/components/Main.jsx
@@ -7,25 +7,20 @@ const Main = () => {
 	const navigate = useNavigate()
 
 	useEffect(() => {
-		const connect = async () => {
-			try {
-				const response = await await fetch(API.health, {
-					method: 'GET'
-				})
-
-				if (response.status === 200) {
-					setTimeout(() => {
-						setMessage('Backend connected successfully...!')
-						navigate('/signup')
-					}, 300)
-				}
+		fetch(API.health, {
+			method: 'GET'
+		})
+		.then(response => {
+			if (response.status === 200) {
+				setTimeout(() => {
+					setMessage('Backend connected successfully...!')
+					navigate('/signup')
+				}, 300)
 			}
-			catch {
-				setTimeout(() => setMessage('Error connecting backend...!'), 300)
-			}
-		}
-
-		connect()
+		})
+		.catch(() => {
+			setMessage('Error connecting backend...!')
+		})
 	}, [])
 
 	return (

--- a/frontend/src/components/Main.jsx
+++ b/frontend/src/components/Main.jsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { API } from '../api'
+
+const Main = () => {
+	const [message, setMessage] = useState('Connecting to database...!')
+	const navigate = useNavigate()
+
+	useEffect(() => {
+		const connect = async () => {
+			try {
+				const response = await await fetch(API.health, {
+					method: 'GET'
+				})
+
+				if (response.status === 200) {
+					setTimeout(() => { 
+						setMessage('Backend connected successfully...!')
+						navigate('/signup')
+					}, 300)
+				}
+			}
+			catch {
+				setTimeout(() => setMessage('Error connecting backend...!'), 300)
+			}
+		}
+
+		connect()
+	}, [])
+
+	return (
+		<div>{message}</div>
+	)
+}
+
+export default Main

--- a/frontend/src/components/NonProtectedRoute.jsx
+++ b/frontend/src/components/NonProtectedRoute.jsx
@@ -1,0 +1,13 @@
+import { Outlet, Navigate } from 'react-router-dom'
+import { useAuth } from '../contexts/AuthContext'
+
+const NonProtectedRoute = () => {
+  const { user, loading } = useAuth()
+
+  if (loading) { return <div>Loading...!</div> }
+  if (user) { return <Navigate to='/view' /> }
+
+  return <Outlet />
+}
+
+export default NonProtectedRoute

--- a/frontend/src/components/NotFound.jsx
+++ b/frontend/src/components/NotFound.jsx
@@ -1,0 +1,13 @@
+import { useNavigate } from 'react-router-dom'
+
+const NotFound = () => {
+	const navigate = useNavigate()
+	return (
+		<div>
+			<h1>Page not found</h1>
+			<button onClick={() => navigate(-1)}>Go to back</button>
+		</div>
+	)
+}
+
+export default NotFound

--- a/frontend/src/components/ProtectedRoute.jsx
+++ b/frontend/src/components/ProtectedRoute.jsx
@@ -1,0 +1,14 @@
+import { Outlet, Navigate } from 'react-router-dom'
+import { useAuth } from '../contexts/AuthContext'
+
+const ProtectedRoute = () => {
+  const { user } = useAuth()
+
+  if (user) {
+    return <Outlet />
+  } else {
+    return <Navigate to='/login' />
+  }
+}
+
+export default ProtectedRoute

--- a/frontend/src/components/ResetPassword.jsx
+++ b/frontend/src/components/ResetPassword.jsx
@@ -95,7 +95,7 @@ const ResetPassword = () => {
 					</div>
 					<div className='error'>{formErrors.new_password2}</div>
 				</div>
-				<div className='form-item'>
+				<div className='form-submit'>
 					<button type='submit'>Set Password</button>
 				</div>
 			</form>

--- a/frontend/src/components/ResetPassword.jsx
+++ b/frontend/src/components/ResetPassword.jsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { API } from '../api'
+import { getCookie } from '../helper'
+import { useAuth } from '../contexts/AuthContext'
+
+const initialState = {
+	uid: '',
+	token: '',
+	new_password1: '',
+	new_password2: '',
+}
+
+const ResetPassword = () => {
+	const [formData, setFormData] = useState(initialState)
+	const [formErrors, setFormErrors] = useState(initialState)
+	const { setLoading } = useAuth()
+	const navigate = useNavigate()
+	const params = useParams()
+
+	useEffect(() => {
+		setFormData({
+			...formData,
+			uid: params.uid,
+			token: params.token
+		})
+	}, [params])
+
+	const resetPassword = async (e) => {
+		e.preventDefault();
+
+		setFormErrors(initialState)
+
+		const response = await fetch(API.reset_password, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'X-CSRFToken': getCookie('csrftoken'),
+			},
+			body: JSON.stringify(formData),
+			credentials: 'include'
+		})
+
+		if (response.status === 200) {
+			setLoading(true)
+			navigate('/login')
+		} else {
+			const data = await response.json()
+
+			Object.entries(data.errors).forEach(([key, errors]) => {
+				setFormErrors(prevErrors => ({
+					...prevErrors,
+					[key]: errors.join(', ')
+				}));
+			});
+		}
+	}
+
+	return (
+		<div>
+			<hr />
+			<button onClick={() => navigate(-1)}>Go to back</button>
+			<hr />
+			<h1>Reset password</h1>
+			<form onSubmit={resetPassword} className='form'>
+				<input
+					name='uid'
+					type='hidden'
+					value={formData.uid} />
+				<input
+					name='token'
+					type='hidden'
+					value={formData.uid} />
+				<div>
+					<div className='form-item'>
+						<label htmlFor='new_password1'>New Password</label>
+						<input
+							name='new_password1'
+							type='password'
+							value={formData.new_password1}
+							onChange={(e) => setFormData({ ...formData, new_password1: e.target.value })}
+							placeholder='Enter new password' />
+					</div>
+					<div className='error'>{formErrors.new_password1}</div>
+				</div>
+				<div>
+					<div className='form-item'>
+						<label htmlFor='new_password2'>Confirm password</label>
+						<input
+							name='new_password2'
+							type='password'
+							value={formData.new_password2}
+							onChange={(e) => setFormData({ ...formData, new_password2: e.target.value })}
+							placeholder='Enter confrim password' />
+					</div>
+					<div className='error'>{formErrors.new_password2}</div>
+				</div>
+				<div className='form-item'>
+					<button type='submit'>Set Password</button>
+				</div>
+			</form>
+		</div>
+	)
+}
+
+export default ResetPassword

--- a/frontend/src/components/SignUp.jsx
+++ b/frontend/src/components/SignUp.jsx
@@ -1,8 +1,7 @@
 import { useState } from 'react'
-import { Link, useNavigate, Navigate } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { API } from '../api'
 import { getCookie } from '../helper'
-import { useAuth } from '../contexts/AuthContext'
 
 const initialState = {
   first_name: '',
@@ -16,7 +15,6 @@ const initialState = {
 const SignUp = () => {
   const [formData, setFormData] = useState(initialState)
   const [formErrors, setFormErrors] = useState(initialState)
-  const { user, loading } = useAuth()
   const navigate = useNavigate()
 
   const register = async (e) => {
@@ -48,9 +46,6 @@ const SignUp = () => {
       });
     }
   }
-
-  if (loading) { return <div>Loading...!</div> }
-  if (user) { return <Navigate to='/view' /> }
 
   return (
     <div>

--- a/frontend/src/components/SignUp.jsx
+++ b/frontend/src/components/SignUp.jsx
@@ -1,0 +1,140 @@
+import { useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { API } from '../api'
+import { getCookie } from '../helper'
+import { useAuth } from '../contexts/AuthContext'
+
+const initialState = {
+  first_name: '',
+  last_name: '',
+  username: '',
+  email: '',
+  password1: '',
+  password2: '',
+}
+
+const SignUp = () => {
+  const [formData, setFormData] = useState(initialState)
+  const [formErrors, setFormErrors] = useState(initialState)
+  const { user, loading } = useAuth()
+  const navigate = useNavigate()
+
+  const register = async (e) => {
+    e.preventDefault();
+
+    setFormErrors(initialState)
+
+    const response = await fetch(API.register, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRFToken': getCookie('csrftoken'),
+      },
+      body: JSON.stringify(formData),
+      credentials: 'include'
+    })
+
+    if (response.status === 201) {
+      navigate('/login')
+    }
+    else {
+      const data = await response.json()
+
+      Object.entries(data.errors).forEach(([key, errors]) => {
+        setFormErrors(prevErrors => ({
+          ...prevErrors,
+          [key]: errors.join(', ')
+        }));
+      });
+    }
+  }
+
+  if (loading) { return <div>Loading...!</div> }
+  if (user){ return <Navigate to='/edit-profile' /> }
+
+  return (
+    <div>
+      <h1>Register an account</h1>
+      <form onSubmit={register} className='form'>
+        <div>
+          <div className='form-item'>
+            <label htmlFor='first_name'>First name</label>
+            <input
+              name='first_name'
+              value={formData.first_name}
+              onChange={(e) => setFormData({ ...formData, first_name: e.target.value })}
+              placeholder='Enter first name' />
+          </div>
+          <div className='error'>{formErrors.first_name}</div>
+        </div>
+        <div>
+          <div className='form-item'>
+            <label htmlFor='last_name'>Last name</label>
+            <input
+              name='last_name'
+              value={formData.last_name}
+              onChange={(e) => setFormData({ ...formData, last_name: e.target.value })}
+              placeholder='Enter last name' />
+          </div>
+          <div className='error'>{formErrors.last_name}</div>
+        </div>
+        <div>
+          <div className='form-item'>
+            <label htmlFor='username'>User name</label>
+            <input
+              name='username'
+              value={formData.username}
+              onChange={(e) => setFormData({ ...formData, username: e.target.value })}
+              placeholder='Enter username' />
+            <span>This name will be used for login</span>
+          </div>
+          <div className='error'>{formErrors.username}</div>
+        </div>
+        <div>
+          <div className='form-item'>
+            <label htmlFor='email'>Email</label>
+            <input
+              name='email'
+              type='email'
+              value={formData.email}
+              onChange={(e) => setFormData({ ...formData, email: e.target.value })}
+              placeholder='Enter email address' />
+          </div>
+          <div className='error'>{formErrors.email}</div>
+        </div>
+        <div>
+          <div className='form-item'>
+            <label htmlFor='password1'>Password</label>
+            <input
+              name='password1'
+              type='password'
+              value={formData.password1}
+              onChange={(e) => setFormData({ ...formData, password1: e.target.value })}
+              placeholder='Enter password' />
+          </div>
+          <div className='error'>{formErrors.password1}</div>
+        </div>
+        <div>
+          <div className='form-item'>
+            <label htmlFor='password2'>Confirm password</label>
+            <input
+              name='password2'
+              type='password'
+              value={formData.password2}
+              onChange={(e) => setFormData({ ...formData, password2: e.target.value })}
+              placeholder='Enter confrim password' />
+          </div>
+          <div className='error'>{formErrors.password2}</div>
+        </div>
+        <div className='form-item'>
+          <button type='submit'>Sign Up</button>
+        </div>
+      </form>
+      <div>
+        Already have account? <Link to='/login'>Login</Link>
+      </div>
+    </div>
+  )
+}
+
+export default SignUp

--- a/frontend/src/components/SignUp.jsx
+++ b/frontend/src/components/SignUp.jsx
@@ -50,7 +50,7 @@ const SignUp = () => {
   }
 
   if (loading) { return <div>Loading...!</div> }
-  if (user){ return <Navigate to='/edit-profile' /> }
+  if (user) { return <Navigate to='/edit-profile' /> }
 
   return (
     <div>

--- a/frontend/src/components/SignUp.jsx
+++ b/frontend/src/components/SignUp.jsx
@@ -121,7 +121,7 @@ const SignUp = () => {
           </div>
           <div className='error'>{formErrors.password2}</div>
         </div>
-        <div className='form-item'>
+        <div className='form-submit'>
           <button type='submit'>Sign Up</button>
         </div>
       </form>

--- a/frontend/src/components/SignUp.jsx
+++ b/frontend/src/components/SignUp.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, useNavigate, Navigate } from 'react-router-dom'
 import { API } from '../api'
 import { getCookie } from '../helper'
 import { useAuth } from '../contexts/AuthContext'
@@ -50,7 +50,7 @@ const SignUp = () => {
   }
 
   if (loading) { return <div>Loading...!</div> }
-  if (user) { return <Navigate to='/edit-profile' /> }
+  if (user) { return <Navigate to='/view' /> }
 
   return (
     <div>

--- a/frontend/src/components/View.jsx
+++ b/frontend/src/components/View.jsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { API } from '../api'
+import { getCookie } from '../helper'
+import { useAuth } from '../contexts/AuthContext'
+
+const View = () => {
+  return (
+    <div>
+      <hr />
+      <Link to='/logout'>Logout</Link>
+      <hr />
+      <Link to='/edit-profile'>Edit Profile</Link>
+      <hr />
+      <Link to='/change-password'>Change Password</Link>
+    </div>
+  )
+}
+
+export default View

--- a/frontend/src/components/View.jsx
+++ b/frontend/src/components/View.jsx
@@ -1,8 +1,4 @@
-import { useEffect, useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
-import { API } from '../api'
-import { getCookie } from '../helper'
-import { useAuth } from '../contexts/AuthContext'
+import { Link } from 'react-router-dom'
 
 const View = () => {
   return (

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -31,7 +31,6 @@ export const AuthContextProvider = ({ children }) => {
 						email: data.user['email'],
 						first_name: data.user['first_name'],
 						last_name: data.user['last_name'],
-						date_joined: data.user['date_joined']
 					})
 				}
 			}

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -1,0 +1,54 @@
+import { createContext, useContext, useEffect, useState } from "react";
+import { API } from "../api";
+
+const AuthContext = createContext()
+
+export const useAuth = () => useContext(AuthContext)
+
+export const AuthContextProvider = ({ children }) => {
+    const [user, setUser] = useState(null)
+    const [loading, setLoading] = useState(true)
+
+    useEffect(()=>{
+        const whoami = async () => {
+            try {
+                await fetch(API.csrf, {
+                    method: 'GET',
+                    credentials: 'include'
+                })
+
+                const response = await fetch(API.whoami, {
+                    method: 'GET',
+                    credentials: 'include'
+                })
+
+                const data = await response.json()
+
+                if (response.status === 200) {
+                    setUser({
+                        id: data.user['id'],
+                        username: data.user['username'],
+                        email: data.user['email'],
+                        first_name: data.user['first_name'],
+                        last_name: data.user['last_name'],
+                        date_joined: data.user['date_joined']
+                    })
+                }
+            }
+            catch {
+                console.log('Something went wrong')
+            }
+            finally {
+                setTimeout(()=>setLoading(false), 300)
+            }
+        }
+
+        whoami()
+    },[loading])
+
+    return (
+        <AuthContext.Provider value={{ user, setUser, loading, setLoading }}>
+            { children }
+        </AuthContext.Provider>
+    )
+}

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -6,49 +6,49 @@ const AuthContext = createContext()
 export const useAuth = () => useContext(AuthContext)
 
 export const AuthContextProvider = ({ children }) => {
-    const [user, setUser] = useState(null)
-    const [loading, setLoading] = useState(true)
+	const [user, setUser] = useState(null)
+	const [loading, setLoading] = useState(true)
 
-    useEffect(()=>{
-        const whoami = async () => {
-            try {
-                await fetch(API.csrf, {
-                    method: 'GET',
-                    credentials: 'include'
-                })
+	useEffect(() => {
+		const whoami = async () => {
+			try {
+				await fetch(API.csrf, {
+					method: 'GET',
+					credentials: 'include'
+				})
 
-                const response = await fetch(API.whoami, {
-                    method: 'GET',
-                    credentials: 'include'
-                })
+				const response = await fetch(API.whoami, {
+					method: 'GET',
+					credentials: 'include'
+				})
 
-                const data = await response.json()
+				const data = await response.json()
 
-                if (response.status === 200) {
-                    setUser({
-                        id: data.user['id'],
-                        username: data.user['username'],
-                        email: data.user['email'],
-                        first_name: data.user['first_name'],
-                        last_name: data.user['last_name'],
-                        date_joined: data.user['date_joined']
-                    })
-                }
-            }
-            catch {
-                console.log('Something went wrong')
-            }
-            finally {
-                setTimeout(()=>setLoading(false), 300)
-            }
-        }
+				if (response.status === 200) {
+					setUser({
+						id: data.user['id'],
+						username: data.user['username'],
+						email: data.user['email'],
+						first_name: data.user['first_name'],
+						last_name: data.user['last_name'],
+						date_joined: data.user['date_joined']
+					})
+				}
+			}
+			catch {
+				console.log('Something went wrong')
+			}
+			finally {
+				setTimeout(() => setLoading(false), 300)
+			}
+		}
 
-        whoami()
-    },[loading])
+		whoami()
+	}, [loading])
 
-    return (
-        <AuthContext.Provider value={{ user, setUser, loading, setLoading }}>
-            { children }
-        </AuthContext.Provider>
-    )
+	return (
+		<AuthContext.Provider value={{ user, setUser, loading, setLoading }}>
+			{children}
+		</AuthContext.Provider>
+	)
 }

--- a/frontend/src/helper.js
+++ b/frontend/src/helper.js
@@ -1,0 +1,14 @@
+export const getCookie = (name) => {
+  let cookieValue = null;
+  if (document.cookie && document.cookie !== '') {
+    const cookies = document.cookie.split(';');
+    for (let cookie of cookies) {
+      cookie = cookie.trim();
+      if (cookie.startsWith(name + '=')) {
+        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+        break;
+      }
+    }
+  }
+  return cookieValue;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -85,6 +85,11 @@ button:focus-visible {
   font-size: 12px;
 }
 
+.form-submit {
+  margin: 12px;
+  text-align: center;
+}
+
 @media (prefers-color-scheme: light) {
   :root {
     color: #213547;
@@ -94,6 +99,6 @@ button:focus-visible {
     color: #747bff;
   }
   button {
-    background-color: #f9f9f9;
+    background-color: #f3f3f3;
   }
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -54,6 +54,37 @@ button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
+.form {
+  display: flex;
+  flex-direction: column
+}
+
+.form-item {
+  display: flex;
+  margin: 5px 10px;
+}
+
+.form-item > label {
+  min-width: 160px;
+  margin-right: 20px;
+  text-align: left;
+}
+
+.form-item > input {
+  min-width: 400px;
+}
+
+.form-item > span {
+  margin-left: 20px;
+  color: blue;
+  font-size: 12px;
+}
+
+.error {
+  color: red;
+  font-size: 12px;
+}
+
 @media (prefers-color-scheme: light) {
   :root {
     color: #213547;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,16 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.jsx'
+import { AuthContextProvider } from './contexts/AuthContext.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <AuthContextProvider>
+        <App />
+      </AuthContextProvider>
+    </BrowserRouter>
   </StrictMode>,
 )


### PR DESCRIPTION
### PR Description

This PR adds authentication and user-related API views to the Django backend, intended for seamless integration with the React frontend.

Summary
Backend:
Created an accounts app and added the following endpoints in that.
    - `GET /csrf`: Returns a CSRF token for frontend protection
    - `GET /whoami`: Returns current authenticated user details
    - `POST /register`: Registers a new user using `UserCreationForm`
    - `POST /login`: Authenticates the user and starts a session
    - `POST /logout`: Logs out the authenticated user
    - `POST /update`: Updates user profile information
    - `POST /update-password`: Allows users to change their password with session retention
    - `POST /send-password-reset-email`: Allows users to send reset password email. From the mail user will redirect to reset password form in the frontend and on submit it will send request for reset password.
    - `POST /reset-password`: Allows users to reset password followed from reset password email. 
    
Frontend:
    - Add UI related to these endpoints.