### PR TITLE
Add functionality to logout user from all devices and keep current session

### DIFF
--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -7,6 +7,7 @@ urlpatterns = [
     path('register', views.register_view, name='register'),
     path('login', views.login_view, name='login'),
     path('logout', views.logout_view, name='logout'),
+    path('logout-from-all-devices', views.logout_from_all_devices_view),
     path('update', views.update_user_view, name='update'),
     path('update-password', views.update_password_view, name='update-password'),
     path('send-password-reset-email', views.send_reset_password_email, name='send-password-reset-email'),

--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -7,7 +7,7 @@ urlpatterns = [
     path('register', views.register_view, name='register'),
     path('login', views.login_view, name='login'),
     path('logout', views.logout_view, name='logout'),
-    path('logout-from-all-devices', views.logout_from_all_devices_view),
+    path('logout-from-all-devices', views.logout_from_all_devices_view, name='logout-from-all-devices'),
     path('update', views.update_user_view, name='update'),
     path('update-password', views.update_password_view, name='update-password'),
     path('send-password-reset-email', views.send_reset_password_email, name='send-password-reset-email'),

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -92,12 +92,14 @@ def update_password_view(request):
         return JsonResponse({'error': 'User not authenticated.'}, status=401)
 
     data=json.loads(request.body)
+    keep_current_session = data.pop('keep_current_session', False)
     form = PasswordChangeForm(user=request.user, data=data)
 
     if form.is_valid():
         form.save()
-        update_session_auth_hash(request, form.user)
-        return JsonResponse({ 'message': 'Password changed successfully.' }, status=200)
+        if keep_current_session == True:
+            update_session_auth_hash(request, form.user)
+        return JsonResponse({ 'message': 'Password changed successfully' }, status=200)
     else:
         return JsonResponse({'errors': form.errors}, status=400)
 

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -61,16 +61,16 @@ def logout_view(request):
     logout(request)
     return JsonResponse({ 'message': 'User logged out successfully.' }, status=200)
 
-require_http_methods(['POST'])
+@require_POST
 def logout_from_all_devices_view(request):
     if not request.user.is_authenticated:
-        return JsonResponse({'error': 'User not authenticated'}, status=401)
+        return JsonResponse({'error': 'User not authenticated.'}, status=401)
 
     for session in list(Session.objects.filter(expire_date__gte=timezone.now())):
         if session.get_decoded()['_auth_user_id'] == str(request.user.id):
             session.delete()
 
-    return JsonResponse({ 'message': 'Successfully loggout from all devices' }, status=200)
+    return JsonResponse({ 'message': 'Successfully loggout from all devices.' }, status=200)
 
 @require_POST
 def update_user_view(request):
@@ -99,7 +99,7 @@ def update_password_view(request):
         form.save()
         if keep_current_session == True:
             update_session_auth_hash(request, form.user)
-        return JsonResponse({ 'message': 'Password changed successfully' }, status=200)
+        return JsonResponse({ 'message': 'Password changed successfully.' }, status=200)
     else:
         return JsonResponse({'errors': form.errors}, status=400)
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -5,6 +5,7 @@ export const API = {
     register: 'http://localhost:8000/auth/register',
     login: 'http://localhost:8000/auth/login',
     logout: 'http://localhost:8000/auth/logout',
+    logout_from_all_devices: 'http://localhost:8000/auth/logout-from-all-devices',
     update: 'http://localhost:8000/auth/update',
     update_password: 'http://localhost:8000/auth/update-password',
     send_password_reset_email: 'http://localhost:8000/auth/send-password-reset-email',

--- a/frontend/src/components/ChangePassword.jsx
+++ b/frontend/src/components/ChangePassword.jsx
@@ -8,12 +8,13 @@ const initialState = {
 	old_password: '',
 	new_password1: '',
 	new_password2: '',
+	keep_current_session: ''
 }
 
 const ChangePassword = () => {
 	const [formData, setFormData] = useState(initialState)
 	const [formErrors, setFormErrors] = useState(initialState)
-	const { setLoading } = useAuth()
+	const { setUser, setLoading } = useAuth()
 	const navigate = useNavigate()
 
 	const updatePassword = async (e) => {
@@ -33,6 +34,7 @@ const ChangePassword = () => {
 
 		if (response.status === 200) {
 			setLoading(true)
+			setUser(null)
 			navigate('/view')
 		} else {
 			const data = await response.json()
@@ -88,6 +90,19 @@ const ChangePassword = () => {
 							placeholder='Enter confrim password' />
 					</div>
 					<div className='error'>{formErrors.new_password2}</div>
+				</div>
+				<div>
+					<div className='form-item'>
+						<label htmlFor='keep_current_session'>
+							<input
+								name='keep_current_session'
+								type='checkbox'
+								checked={formData.keep_current_session}
+								onChange={(e) => setFormData({ ...formData, keep_current_session: e.target.checked })} />
+							Stay signed in on this browser
+						</label>
+					</div>
+					<div className='error'>{formErrors.keep_current_session}</div>
 				</div>
 				<div className='form-submit'>
 					<button type='submit'>Update</button>

--- a/frontend/src/components/Logout.jsx
+++ b/frontend/src/components/Logout.jsx
@@ -31,15 +31,39 @@ const Logout = () => {
     }
   }
 
+  const logoutFromAllDevices = async (e) => {
+    setError('')
+    const response = await fetch(API.logout_from_all_devices, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRFToken': getCookie('csrftoken'),
+      },
+      credentials: 'include'
+    })
+
+    if (response.status === 200) {
+      setLoading(true)
+      setUser(null)
+      navigate('/login')
+    }
+    else {
+      const data = await response.json()
+      setError(data.message)
+    }
+  }
+
   return (
     <div>
       {
         user ? (
           <>
-            <div className='error'>{error}</div>
-            <h2>Hi {user.username} - Are you sure you want to logout?</h2>
-            <button onClick={logout}>Logout</button>
             <button onClick={() => navigate(-1)}>Go to back</button>
+            <hr />
+            <div className='error'>{error}</div>
+            <h2>Hi {user.username} - Do you want to logout or logged out from all devices?</h2>
+            <button onClick={logout}>Logout</button>
+            <button onClick={logoutFromAllDevices}>Logout from all devices</button>
           </>
         ) : (
           <div>Loading....</div>


### PR DESCRIPTION
### PR Description
This PR adds a feature that allows users to securely log out from all active sessions across all devices. I implemented logic to invalidate all existing sessions for a user in this way we Improves account security by allowing users to revoke access from all devices in cases where a user's credentials may be compromised or a session is forgotten on a shared device. The password change also invalidate all sessions so I add checkbox `Stay signed in on this browser` to keep the current session of user.

**Testing**
- I verified that all sessions are cleared after triggering `logout of all devices` or on 'Change Password'.
- The current session is also terminated but not when `Stay signed in on this browser` is checked.